### PR TITLE
ovn: do not send direct traffic between lports to conntrack

### DIFF
--- a/dist/images/Dockerfile.base
+++ b/dist/images/Dockerfile.base
@@ -29,8 +29,8 @@ RUN cd /usr/src/ && \
 
 RUN cd /usr/src/ && git clone -b branch-22.12 --depth=1 https://github.com/ovn-org/ovn.git && \
     cd ovn && \
-    # do not send traffic that not designate to svc to conntrack
-    curl -s https://github.com/kubeovn/ovn/commit/961e67eff786fe219c98054a7af5409cc0fb52cc.patch | git apply && \
+    # do not send direct traffic between lports to conntrack
+    curl -s https://github.com/kubeovn/ovn/commit/4124fb623183541b80a577846ce145c7faf8eb5d.patch | git apply && \
     # change hash type from dp_hash to hash with field src_ip
     curl -s https://github.com/kubeovn/ovn/commit/daa09e380eec61620d4ee317e3265c44366d1147.patch | git apply && \
     # set ether dst addr for dnat on logical switch

--- a/mocks/pkg/ovs/interface.go
+++ b/mocks/pkg/ovs/interface.go
@@ -82,20 +82,6 @@ func (mr *MockNBGlobalMockRecorder) SetICAutoRoute(enable, blackList interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetICAutoRoute", reflect.TypeOf((*MockNBGlobal)(nil).SetICAutoRoute), enable, blackList)
 }
 
-// SetLBCIDR mocks base method.
-func (m *MockNBGlobal) SetLBCIDR(serviceCIDR string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetLBCIDR", serviceCIDR)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetLBCIDR indicates an expected call of SetLBCIDR.
-func (mr *MockNBGlobalMockRecorder) SetLBCIDR(serviceCIDR interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLBCIDR", reflect.TypeOf((*MockNBGlobal)(nil).SetLBCIDR), serviceCIDR)
-}
-
 // SetLsDnatModDlDst mocks base method.
 func (m *MockNBGlobal) SetLsDnatModDlDst(enabled bool) error {
 	m.ctrl.T.Helper()
@@ -3322,20 +3308,6 @@ func (m *MockOvnClient) SetICAutoRoute(enable bool, blackList []string) error {
 func (mr *MockOvnClientMockRecorder) SetICAutoRoute(enable, blackList interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetICAutoRoute", reflect.TypeOf((*MockOvnClient)(nil).SetICAutoRoute), enable, blackList)
-}
-
-// SetLBCIDR mocks base method.
-func (m *MockOvnClient) SetLBCIDR(serviceCIDR string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetLBCIDR", serviceCIDR)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// SetLBCIDR indicates an expected call of SetLBCIDR.
-func (mr *MockOvnClientMockRecorder) SetLBCIDR(serviceCIDR interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLBCIDR", reflect.TypeOf((*MockOvnClient)(nil).SetLBCIDR), serviceCIDR)
 }
 
 // SetLoadBalancerAffinityTimeout mocks base method.

--- a/pkg/controller/init.go
+++ b/pkg/controller/init.go
@@ -32,13 +32,6 @@ func (c *Controller) InitOVN() error {
 			klog.Errorf("init load balancer failed: %v", err)
 			return err
 		}
-		v4Svc, _ := util.SplitStringIP(c.config.ServiceClusterIPRange)
-		if v4Svc != "" {
-			if err := c.ovnClient.SetLBCIDR(v4Svc); err != nil {
-				klog.Errorf("init load balancer svc cidr failed: %v", err)
-				return err
-			}
-		}
 	}
 
 	if err := c.initDefaultVlan(); err != nil {

--- a/pkg/ovs/interface.go
+++ b/pkg/ovs/interface.go
@@ -15,7 +15,6 @@ type NBGlobal interface {
 	SetAzName(azName string) error
 	SetUseCtInvMatch() error
 	SetICAutoRoute(enable bool, blackList []string) error
-	SetLBCIDR(serviceCIDR string) error
 	SetLsDnatModDlDst(enabled bool) error
 	GetNbGlobal() (*ovnnb.NBGlobal, error)
 }


### PR DESCRIPTION
- [x] Make sure you have followed [Kube-OVN Code Style](https://github.com/kubeovn/kube-ovn/blob/master/CODE_STYLE.md).

### What type of this PR

- Bug fixes

### Which issue(s) this PR fixes:
Fixes #(issue-number)

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough